### PR TITLE
Fixed slb load balancer and Access control operations.

### DIFF
--- a/apsarastack/data_source_apsarastack_slb_acls.go
+++ b/apsarastack/data_source_apsarastack_slb_acls.go
@@ -33,11 +33,6 @@ func dataSourceApsaraStackSlbAcls() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"resource_group_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
 			// Computed values
 			"names": {
 				Type:     schema.TypeList,
@@ -104,10 +99,6 @@ func dataSourceApsaraStackSlbAcls() *schema.Resource {
 							MinItems: 0,
 						},
 						"tags": tagsSchema(),
-						"resource_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 					},
 				},
 			},
@@ -119,7 +110,6 @@ func dataSourceApsaraStackSlbAclsRead(d *schema.ResourceData, meta interface{}) 
 	client := meta.(*connectivity.ApsaraStackClient)
 	request := slb.CreateDescribeAccessControlListsRequest()
 	request.RegionId = client.RegionId
-	request.ResourceGroupId = d.Get("resource_group_id").(string)
 	tags := d.Get("tags").(map[string]interface{})
 	if tags != nil && len(tags) > 0 {
 		KeyPairsTags := make([]slb.DescribeAccessControlListsTag, 0, len(tags))
@@ -209,7 +199,6 @@ func slbAclsDescriptionAttributes(d *schema.ResourceData, acls []slb.Acl, client
 			"entry_list":        slbService.FlattenSlbAclEntryMappings(response.AclEntrys.AclEntry),
 			"related_listeners": slbService.flattenSlbRelatedListenerMappings(response.RelatedListeners.RelatedListener),
 			"tags":              aclTagsMappings(d, response.AclId, meta),
-			"resource_group_id": response.ResourceGroupId,
 		}
 
 		ids = append(ids, response.AclId)

--- a/apsarastack/data_source_apsarastack_slb_acls_test.go
+++ b/apsarastack/data_source_apsarastack_slb_acls_test.go
@@ -3,7 +3,6 @@ package apsarastack
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"os"
 	"strings"
 	"testing"
 )
@@ -38,28 +37,14 @@ func TestAccApsaraStackSlbAclsDataSource_basic(t *testing.T) {
 		}),
 	}
 
-	resourceGroupIdConf := dataSourceTestAccConfig{
-		existConfig: testAccCheckApsaraStackSlbAclsDataSourceConfig(rand, map[string]string{
-			"ids":               `["${apsarastack_slb_acl.default.id}"]`,
-			"resource_group_id": `""`,
-		}),
-		fakeConfig: testAccCheckApsaraStackSlbAclsDataSourceConfig(rand, map[string]string{
-			"ids":               `["${apsarastack_slb_acl.default.id}_fake"]`,
-			"resource_group_id": fmt.Sprintf(`"%s_fake"`, os.Getenv("APSARASTACK_RESOURCE_GROUP_ID")),
-		}),
-	}
-
 	allConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckApsaraStackSlbAclsDataSourceConfig(rand, map[string]string{
 			"ids":        `["${apsarastack_slb_acl.default.id}"]`,
 			"name_regex": `"${apsarastack_slb_acl.default.name}"`,
-			// The resource route tables do not support resource_group_id, so it was set empty.
-			"resource_group_id": `""`,
 		}),
 		fakeConfig: testAccCheckApsaraStackSlbAclsDataSourceConfig(rand, map[string]string{
-			"ids":               `["${apsarastack_slb_acl.default.id}_fake"]`,
-			"name_regex":        `"${apsarastack_slb_acl.default.name}"`,
-			"resource_group_id": `""`,
+			"ids":        `["${apsarastack_slb_acl.default.id}_fake"]`,
+			"name_regex": `"${apsarastack_slb_acl.default.name}"`,
 		}),
 	}
 
@@ -69,7 +54,6 @@ func TestAccApsaraStackSlbAclsDataSource_basic(t *testing.T) {
 			"ids.#":                      "1",
 			"names.#":                    "1",
 			"acls.0.id":                  CHECKSET,
-			"acls.0.resource_group_id":   CHECKSET,
 			"acls.0.name":                fmt.Sprintf("tf-testAccSlbAclDataSourceBisic-%d", rand),
 			"acls.0.ip_version":          "ipv4",
 			"acls.0.entry_list.#":        "2",
@@ -94,7 +78,7 @@ func TestAccApsaraStackSlbAclsDataSource_basic(t *testing.T) {
 		fakeMapFunc:  fakeDnsRecordsMapFunc,
 	}
 
-	slbaclsCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, tagsConf, idsConf, resourceGroupIdConf, allConf)
+	slbaclsCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, tagsConf, idsConf, allConf)
 }
 
 func testAccCheckApsaraStackSlbAclsDataSourceConfig(rand int, attrMap map[string]string) string {

--- a/apsarastack/data_source_apsarastack_slbs.go
+++ b/apsarastack/data_source_apsarastack_slbs.go
@@ -73,11 +73,6 @@ func dataSourceApsaraStackSlbs() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"resource_group_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
 			// Computed values
 			"slbs": {
 				Type:     schema.TypeList,
@@ -141,7 +136,7 @@ func dataSourceApsaraStackSlbsRead(d *schema.ResourceData, meta interface{}) err
 
 	request := slb.CreateDescribeLoadBalancersRequest()
 	request.RegionId = client.RegionId
-	request.ResourceGroupId = d.Get("resource_group_id").(string)
+	//request.ResourceGroupId = d.Get("resource_group_id").(string)
 	if v, ok := d.GetOk("master_availability_zone"); ok && v.(string) != "" {
 		request.MasterZoneId = v.(string)
 	}

--- a/apsarastack/data_source_apsarastack_slbs_test.go
+++ b/apsarastack/data_source_apsarastack_slbs_test.go
@@ -100,7 +100,6 @@ func TestAccApsaraStackSlbsDataSource(t *testing.T) {
 			"network_type":             `"vpc"`,
 			"tags":                     `{tag_f = 6}`,
 			"master_availability_zone": `"${data.apsarastack_zones.default.zones.0.id}"`,
-			"resource_group_id":        fmt.Sprintf(`"%s"`, os.Getenv("APSARASTACK_RESOURCE_GROUP_ID")),
 		}),
 		fakeConfig: testAccCheckApsaraStackSlbDataSourceConfig(rand, map[string]string{
 			"name_regex":               `"${apsarastack_slb.default.name}_fake"`,
@@ -110,7 +109,6 @@ func TestAccApsaraStackSlbsDataSource(t *testing.T) {
 			"network_type":             `"vpc"`,
 			"tags":                     `{tag_f = 6}`,
 			"master_availability_zone": `"${data.apsarastack_zones.default.zones.0.id}"`,
-			"resource_group_id":        fmt.Sprintf(`"%s"`, os.Getenv("APSARASTACK_RESOURCE_GROUP_ID")),
 		}),
 	}
 
@@ -120,7 +118,7 @@ func TestAccApsaraStackSlbsDataSource(t *testing.T) {
 			"ids.#":                           "1",
 			"names.#":                         "1",
 			"slbs.0.id":                       CHECKSET,
-			"slbs.0.name":                     fmt.Sprintf("tf-testAccCheckAlicloudSlbsDataSourceBasic-%d", rand),
+			"slbs.0.name":                     fmt.Sprintf("tf-testAccCheckApsaraStackSlbsDataSourceBasic-%d", rand),
 			"slbs.0.region_id":                CHECKSET,
 			"slbs.0.master_availability_zone": CHECKSET,
 			"slbs.0.slave_availability_zone":  CHECKSET,
@@ -161,7 +159,7 @@ func testAccCheckApsaraStackSlbDataSourceConfig(rand int, attrMap map[string]str
 
 	config := fmt.Sprintf(`
 variable "name" {
-	default = "tf-testAccCheckAlicloudSlbsDataSourceBasic-%d"
+	default = "tf-testAccCheckApsaraStackSlbsDataSourceBasic-%d"
 }
 
 data "apsarastack_zones" "default" {
@@ -194,12 +192,11 @@ resource "apsarastack_slb" "default" {
     tag_g = 7
     tag_h = 8
   }
-  resource_group_id = "%s"
 }
 
 data "apsarastack_slbs" "default" {
   %s
 }
-`, rand, os.Getenv("APSARASTACK_RESOURCE_GROUP_ID"), strings.Join(pairs, "\n  "))
+`, rand, strings.Join(pairs, "\n  "))
 	return config
 }

--- a/apsarastack/resource_apsarastack_slb_acl.go
+++ b/apsarastack/resource_apsarastack_slb_acl.go
@@ -28,12 +28,6 @@ func resourceApsaraStackSlbAcl() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"resource_group_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
 			"ip_version": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -69,9 +63,6 @@ func resourceApsaraStackSlbAclCreate(d *schema.ResourceData, meta interface{}) e
 
 	request := slb.CreateCreateAccessControlListRequest()
 	request.RegionId = client.RegionId
-	if v := d.Get("resource_group_id").(string); v != "" {
-		request.ResourceGroupId = v
-	}
 	request.AclName = strings.TrimSpace(d.Get("name").(string))
 	request.AddressIPVersion = d.Get("ip_version").(string)
 
@@ -107,7 +98,6 @@ func resourceApsaraStackSlbAclRead(d *schema.ResourceData, meta interface{}) err
 		return WrapError(err)
 	}
 	d.Set("name", object.AclName)
-	d.Set("resource_group_id", object.ResourceGroupId)
 	d.Set("ip_version", object.AddressIPVersion)
 
 	if err := d.Set("entry_list", slbService.FlattenSlbAclEntryMappings(object.AclEntrys.AclEntry)); err != nil {

--- a/apsarastack/resource_apsarastack_slb_acl_test.go
+++ b/apsarastack/resource_apsarastack_slb_acl_test.go
@@ -3,7 +3,6 @@ package apsarastack
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 	"testing"
 
@@ -109,17 +108,15 @@ func TestAccApsaraStackSlbAcl_basic(t *testing.T) {
 						"Created": "TF",
 						"For":     "acceptance test123",
 					},
-					"resource_group_id": os.Getenv("APSARASTACK_RESOURCE_GROUP_ID"),
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"name":              "tf-testAccSlbAcl",
-						"ip_version":        "ipv4",
-						"entry_list.#":      "2",
-						"tags.%":            "2",
-						"tags.Created":      "TF",
-						"tags.For":          "acceptance test123",
-						"resource_group_id": CHECKSET,
+						"name":         "tf-testAccSlbAcl",
+						"ip_version":   "ipv4",
+						"entry_list.#": "2",
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "acceptance test123",
 					}),
 				),
 			},

--- a/apsarastack/resource_apsarastack_slb_test.go
+++ b/apsarastack/resource_apsarastack_slb_test.go
@@ -140,31 +140,26 @@ func TestAccApsaraStackSlb_classictest(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"name": name,
+					"name":         name,
+					"address_type": "internet",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"name":               name,
-						"address_type":       "internet",
-						"master_zone_id":     CHECKSET,
-						"slave_zone_id":      CHECKSET,
-						"address_ip_version": "ipv4",
+						"name":         name,
+						"address_type": "internet",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"name":         name,
+					"internet":     REMOVEKEY,
 					"address_type": "intranet",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"name":               name,
-						"address_type":       "intranet",
-						"master_zone_id":     CHECKSET,
-						"slave_zone_id":      CHECKSET,
-						"address_ip_version": "ipv4",
-						"resource_group_id":  CHECKSET,
+						"name":         name,
+						"address_type": "intranet",
 					}),
 				),
 			},
@@ -173,7 +168,6 @@ func TestAccApsaraStackSlb_classictest(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"name": fmt.Sprintf("tf-testAccSlbClassicInstanceConfigSpot%d_change", rand),
@@ -184,7 +178,6 @@ func TestAccApsaraStackSlb_classictest(t *testing.T) {
 					}),
 				),
 			},
-
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"tags": map[string]string{
@@ -213,26 +206,14 @@ func TestAccApsaraStackSlb_classictest(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"name":           name,
-						"address_type":   "internet",
-						"master_zone_id": CHECKSET,
-						"slave_zone_id":  CHECKSET,
-						"tags.%":         REMOVEKEY,
-						"tags.tag_A1":    REMOVEKEY,
-						"tags.tag_B2":    REMOVEKEY,
-						"tags.tag_C3":    REMOVEKEY,
-						"tags.tag_D4":    REMOVEKEY,
-						"tags.tag_E5":    REMOVEKEY,
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"address_ip_version": "ipv6",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"address_ip_version": "ipv6",
+						"name":         name,
+						"address_type": "internet",
+						"tags.%":       REMOVEKEY,
+						"tags.tag_A1":  REMOVEKEY,
+						"tags.tag_B2":  REMOVEKEY,
+						"tags.tag_C3":  REMOVEKEY,
+						"tags.tag_D4":  REMOVEKEY,
+						"tags.tag_E5":  REMOVEKEY,
 					}),
 				),
 			},
@@ -266,17 +247,12 @@ func TestAccApsaraStackSlb_vpctest(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"name":              name,
-					"vswitch_id":        "${apsarastack_vswitch.default.id}",
-					"delete_protection": "on",
+					"name":       name,
+					"vswitch_id": "${apsarastack_vswitch.default.id}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"name":              name,
-						"master_zone_id":    CHECKSET,
-						"slave_zone_id":     CHECKSET,
-						"delete_protection": "on",
-						"resource_group_id": CHECKSET,
+						"name": name,
 					}),
 				),
 			},
@@ -284,16 +260,6 @@ func TestAccApsaraStackSlb_vpctest(t *testing.T) {
 				ResourceName:      resourceId,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"delete_protection": "off",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"delete_protection": "off",
-					}),
-				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -328,16 +294,12 @@ func TestAccApsaraStackSlb_vpctest(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"name":              name,
-					"delete_protection": "off",
+					"name": name,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"name":              name,
-						"tags.%":            REMOVEKEY,
-						"master_zone_id":    CHECKSET,
-						"slave_zone_id":     CHECKSET,
-						"delete_protection": "off",
+						"name":   name,
+						"tags.%": REMOVEKEY,
 					}),
 				),
 			},
@@ -384,16 +346,13 @@ func TestAccApsaraStackSlb_vpcmulti(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"name":              name,
-						"tags.%":            "5",
-						"tags.tag_A1":       "value_A1",
-						"tags.tag_B2":       "value_B2",
-						"tags.tag_C3":       "value_C3",
-						"tags.tag_D4":       "value_D4",
-						"tags.tag_E5":       "value_E5",
-						"master_zone_id":    CHECKSET,
-						"slave_zone_id":     CHECKSET,
-						"resource_group_id": CHECKSET,
+						"name":        name,
+						"tags.%":      "5",
+						"tags.tag_A1": "value_A1",
+						"tags.tag_B2": "value_B2",
+						"tags.tag_C3": "value_C3",
+						"tags.tag_D4": "value_D4",
+						"tags.tag_E5": "value_E5",
 					}),
 				),
 			},

--- a/website/docs/d/slb_zones.html.markdown
+++ b/website/docs/d/slb_zones.html.markdown
@@ -4,12 +4,12 @@ layout: "apsarastack"
 page_title: "Apsarastack: apsarastack_slb_zones"
 sidebar_current: "docs-apsarastack-datasource-slb-zones"
 description: |-
-    Provides a list of availability zones for SLB that can be used by an Alibaba Cloud account.
+    Provides a list of availability zones for SLB that can be used by an ApsaraStack Cloud account.
 ---
 
 # apsarastack\_slb\_zones
 
-This data source provides availability zones for SLB that can be accessed by an Alibaba Cloud account within the region configured in the provider.
+This data source provides availability zones for SLB that can be accessed by an ApsaraStack Cloud account within the region configured in the provider.
 
 -> **NOTE:** Available in v1.73.0+.
 

--- a/website/docs/r/slb.html.markdown
+++ b/website/docs/r/slb.html.markdown
@@ -75,7 +75,7 @@ Terraform will autogenerate a name beginning with `tf-lb`.
 
 -> **NOTE:** To change a "Shared-Performance" instance to a "Performance-guaranteed" instance, the SLB will have a short probability of business interruption (10 seconds-30 seconds). Advise to change it during the business downturn, or migrate business to other SLB Instances by using GSLB before changing.
 
--> **NOTE:** Currently, the alibaba cloud international account does not support creating a PrePaid SLB instance.
+-> **NOTE:** Currently, the apsarastack cloud international account does not support creating a PrePaid SLB instance.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR resolved the following points that came in Load Balancer (SLB) instances and Access control operations.
- Remove Unreachable code.
- Removes inessential parameter, APSARASTACK_RESOURCE_GROUP_ID from SLB instances and Access control operations.
- Correction in documents.